### PR TITLE
use env var for secret, stdout for optional second arg

### DIFF
--- a/README
+++ b/README
@@ -1,21 +1,21 @@
 This python script will fetch the latest subscription videos for a 
 named Youtube user. Usage:
 
-./ytsubs.py <username> <output RSS file>
+    YOUTUBE_SERVER_API_KEY="<your_secret_key>" ./ytsubs.py <username> <output RSS file>
 
 I recommend to put this into a cronjob so that it will only update
 hourly due to the extreme inefficiency of the V3 API (see below).
 
 The script uses the Youtube V3 API which requires you to create an 
 application on the Google developer console before you can make 
-requests. After you make the application you must enable Youtube API 
-access and create a server API key.
+requests. After you make the application you must enable
+'YouTube Data API v3' access and create a server API key.
 
 This is all explained here:
 
 https://developers.google.com/youtube/registering_an_application
 
-After you get your API key, put it into the python file. Note that
+After you get your API key, add it to the command above. Note that
 the API key owner does not need to be the same user you want to get
 subscription videos for. The API allows you to read subscriptions
 of any user who hasn't set their account to private.

--- a/ytsubs.py
+++ b/ytsubs.py
@@ -26,11 +26,21 @@
 import urllib2
 import json
 import itertools
+import os
 import sys
 from xml.etree.ElementTree import Element, SubElement, Comment, tostring
 
 baseurl = 'https://www.googleapis.com/youtube/v3'
-my_key = 'youtube secret server key'
+my_key = os.environ.get('YOUTUBE_SERVER_API_KEY')
+
+# check for missing inputs
+if not my_key:
+  print "YOUTUBE_SERVER_API_KEY variable missing."
+  sys.exit(-1)
+
+if not len(sys.argv) >= 2:
+  print "username and (optionally) destination file must be specified as first and second arguments."
+  sys.exit(-1)
 
 def get_channel_for_user(user):
     url = baseurl + '/channels?part=id&forUsername='+ user + '&key=' + my_key
@@ -148,7 +158,11 @@ for v in sortedvids[:20]:
     description = SubElement(item, 'description')
     description.text = v['snippet']['description']
 
-f = open(sys.argv[2], 'w')
+if len(sys.argv) >= 3:
+  filename = sys.argv[2]
+  f = open(filename, 'w')
+else:
+  f = sys.stdout
 f.write('<?xml version="1.0" encoding="UTF-8" ?>')
 f.write(tostring(rss).encode('utf-8'))
 f.close()


### PR DESCRIPTION
I moved the API secret key to an environment variable- that removes the need to change the source script. If nothing else, that reduces the risk of committing a key accidentally.

I also made the second argument (the filename) optional, so the script can print to stdout instead.